### PR TITLE
Add edebug-eval-expression to mini-frame-ignore-commands.

### DIFF
--- a/mini-frame.el
+++ b/mini-frame.el
@@ -68,7 +68,7 @@
   "Show minibuffer in child frame."
   :group 'minibuffer)
 
-(defcustom mini-frame-ignore-commands '(eval-expression)
+(defcustom mini-frame-ignore-commands '(eval-expression edebug-eval-expression)
   "For this commands minibuffer will not be displayed in child frame."
   :type '(repeat function))
 


### PR DESCRIPTION
Needed for the same reason as eval-expression.