### PR TITLE
fix: make bytecode compiler don't optimize vars away

### DIFF
--- a/mini-frame.el
+++ b/mini-frame.el
@@ -272,6 +272,9 @@ ALIST is passed to `window--display-buffer'."
       (make-frame-invisible mini-frame-completions-frame))
     (select-frame-set-input-focus mini-frame-selected-frame))))
 
+(defvar which-key-popup-type)
+(defvar ivy-fixed-height-minibuffer)
+
 (defun mini-frame-read-from-minibuffer (fn &rest args)
   "Show minibuffer-only child frame (if needed) and call FN with ARGS."
   (cond


### PR DESCRIPTION
It seems that without declare (or forward declare) the variable, it will be optimized away by byte-code compiler.
That make temporary lexical binding those variables useless.