### PR TITLE
save window-excursion & current-buffer

### DIFF
--- a/mini-frame.el
+++ b/mini-frame.el
@@ -345,9 +345,7 @@ ALIST is passed to `window--display-buffer'."
    ((and (frame-live-p mini-frame-frame)
          (frame-parameter mini-frame-frame 'parent-frame)
          (frame-visible-p mini-frame-frame))
-    (save-current-buffer
-      (save-window-excursion
-        (mini-frame--display fn args))))
+    (mini-frame--display fn args))
    (t
     ;; On windows `frame-visible-p' can be t even if the frame is not visible so
     ;; calling `make-frame-visible' doesn't make frame actually visible.  Make frame

--- a/mini-frame.el
+++ b/mini-frame.el
@@ -347,7 +347,7 @@ ALIST is passed to `window--display-buffer'."
          (frame-visible-p mini-frame-frame))
     (save-current-buffer
       (save-window-excursion
-	(mini-frame--display fn args))))
+        (mini-frame--display fn args))))
    (t
     ;; On windows `frame-visible-p' can be t even if the frame is not visible so
     ;; calling `make-frame-visible' doesn't make frame actually visible.  Make frame
@@ -379,17 +379,17 @@ ALIST is passed to `window--display-buffer'."
       (ignore resize-mini-frames)
       (ignore which-key-popup-type)
       (save-current-buffer
-	(save-window-excursion
-	  (unwind-protect
-	      (mini-frame--display fn args)
-	    (when (frame-live-p mini-frame-completions-frame)
-	      (make-frame-invisible mini-frame-completions-frame))
-	    (when (frame-live-p mini-frame-selected-frame)
-	      (select-frame-set-input-focus mini-frame-selected-frame))
-	    (when (frame-live-p mini-frame-frame)
-	      (make-frame-invisible mini-frame-frame)
-	      (when mini-frame-detach-on-hide
-		(modify-frame-parameters mini-frame-frame '((parent-frame . nil))))))))))))
+        (save-window-excursion
+          (unwind-protect
+              (mini-frame--display fn args)
+            (when (frame-live-p mini-frame-completions-frame)
+              (make-frame-invisible mini-frame-completions-frame))
+            (when (frame-live-p mini-frame-selected-frame)
+              (select-frame-set-input-focus mini-frame-selected-frame))
+            (when (frame-live-p mini-frame-frame)
+              (make-frame-invisible mini-frame-frame)
+              (when mini-frame-detach-on-hide
+                (modify-frame-parameters mini-frame-frame '((parent-frame . nil))))))))))))
 
 ;; http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=2ecbf4cfae
 ;; By default minibuffer is moved onto active frame leaving empty mini-frame.

--- a/mini-frame.el
+++ b/mini-frame.el
@@ -345,8 +345,9 @@ ALIST is passed to `window--display-buffer'."
    ((and (frame-live-p mini-frame-frame)
          (frame-parameter mini-frame-frame 'parent-frame)
          (frame-visible-p mini-frame-frame))
-    (save-excursion
-      (mini-frame--display fn args)))
+    (save-current-buffer
+      (save-window-excursion
+	(mini-frame--display fn args))))
    (t
     ;; On windows `frame-visible-p' can be t even if the frame is not visible so
     ;; calling `make-frame-visible' doesn't make frame actually visible.  Make frame
@@ -377,17 +378,18 @@ ALIST is passed to `window--display-buffer'."
       (ignore ivy-fixed-height-minibuffer)
       (ignore resize-mini-frames)
       (ignore which-key-popup-type)
-      (save-excursion
-        (unwind-protect
-            (mini-frame--display fn args)
-          (when (frame-live-p mini-frame-completions-frame)
-            (make-frame-invisible mini-frame-completions-frame))
-          (when (frame-live-p mini-frame-selected-frame)
-            (select-frame-set-input-focus mini-frame-selected-frame))
-          (when (frame-live-p mini-frame-frame)
-            (make-frame-invisible mini-frame-frame)
-            (when mini-frame-detach-on-hide
-              (modify-frame-parameters mini-frame-frame '((parent-frame . nil)))))))))))
+      (save-current-buffer
+	(save-window-excursion
+	  (unwind-protect
+	      (mini-frame--display fn args)
+	    (when (frame-live-p mini-frame-completions-frame)
+	      (make-frame-invisible mini-frame-completions-frame))
+	    (when (frame-live-p mini-frame-selected-frame)
+	      (select-frame-set-input-focus mini-frame-selected-frame))
+	    (when (frame-live-p mini-frame-frame)
+	      (make-frame-invisible mini-frame-frame)
+	      (when mini-frame-detach-on-hide
+		(modify-frame-parameters mini-frame-frame '((parent-frame . nil))))))))))))
 
 ;; http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=2ecbf4cfae
 ;; By default minibuffer is moved onto active frame leaving empty mini-frame.


### PR DESCRIPTION
On exit, the default minibuffer implementation restores:

1. The current buffer.
2. The window configuration.

See: https://github.com/emacs-mirror/emacs/blob/e1902ac6182b156efaaf93013a707abb4b627765/src/minibuf.c#L590-L601

This patch replaces the calls to `save-excursion` with calls to `save-current-buffer` and `save-window-excursion` to mimic this behavior. Specifically:

1. Point is no longer restored when exiting `mini-frame`, just the current buffer.
2. The window configuration _is_ restored.

See https://github.com/minad/consult/issues/178 for the original issue.

Huge thanks to @minad for figuring this out.