### PR TITLE
Frame resizing takes into account the size of the input area

### DIFF
--- a/mini-frame.el
+++ b/mini-frame.el
@@ -216,7 +216,10 @@ This function used as value for `resize-mini-frames' variable."
                (max (frame-parameter frame 'height)
                     mini-frame-resize-min-height)
              mini-frame-resize-min-height)
-           nil nil 'vertically)
+           ;; Using the `only' parameter causes the fit to ignore the actual
+           ;; input area of the mini-window
+           (frame-parameter frame 'width)
+           (frame-parameter frame 'width))
   (when (and (frame-live-p mini-frame-completions-frame)
              (frame-visible-p mini-frame-completions-frame))
     (let ((show-parameters (if (functionp mini-frame-completions-show-parameters)


### PR DESCRIPTION
For some reason, the height of the input area is excluded from the fit-to-frame calculations. This only happens when the `only` argument is used. `fit-mini-frame-to-buffer` forces no additional arguments other than `frame`, so maybe there is a reason for all of this. 

`only` was used to constrain the horizontal size of the mini-frame, which can be done equivalently by setting a min and max instead. This allows the vertical resize to happen and take into account any sized input area.

## Before

<img width="505" alt="CleanShot 2022-06-19 at 21 39 49@2x" src="https://user-images.githubusercontent.com/8588/174510737-571870c9-155a-4d0e-bf05-5e04ef5a7286.png">

## After

<img width="481" alt="CleanShot 2022-06-19 at 21 40 03@2x" src="https://user-images.githubusercontent.com/8588/174510746-501d7072-336a-4b24-b0d3-4e6682557ff4.png">

