### PR TITLE
Remove needless quote

### DIFF
--- a/mini-frame.el
+++ b/mini-frame.el
@@ -106,7 +106,7 @@ Called if `mini-frame-show-parameters' doesn't specify background color."
   "When set, set the internal border color of mini-frames to this color."
   :type '(choice (const :tag "Not set" nil)
                  (color :tag "Color")
-                 (const :tag "Unspecified" 'unspecified)))
+                 (const :tag "Unspecified" unspecified)))
 
 (defcustom mini-frame-handle-completions t
   "Create child frame to display completions buffer."


### PR DESCRIPTION
This fixes the following byte-compile warning

```
mini-frame.el:105:12: Warning: defcustom for
    ‘mini-frame-internal-border-color’ has syntactically odd type ‘'(choice
    (const :tag Not set nil) (color :tag Color) (const :tag Unspecified
    'unspecified))’
```