### PR TITLE
de-stringify edebug-eval-expression in mini-frame-ignore-commands

### DIFF
--- a/mini-frame.el
+++ b/mini-frame.el
@@ -73,7 +73,7 @@
 Set this variable before `mini-frame' mode activation."
   :type '(repeat function))
 
-(defcustom mini-frame-ignore-commands '(eval-expression "edebug-eval-expression" debugger-eval-expression)
+(defcustom mini-frame-ignore-commands '(eval-expression edebug-eval-expression debugger-eval-expression)
   "For this commands minibuffer will not be displayed in child frame."
   :type '(repeat (choice function regexp)))
 


### PR DESCRIPTION
Potential fix for https://github.com/muffinmad/emacs-mini-frame/issues/72?